### PR TITLE
Corrected mistake in 2(d), no decimal

### DIFF
--- a/Ch03/Exercises/e2.c
+++ b/Ch03/Exercises/e2.c
@@ -21,7 +21,7 @@ int main(void)
     printf("a|%-8.1e|\n", x);
     printf("b|%10.6e|\n", x);
     printf("c|%-8.3f|\n", x);
-    printf("d|%6f|\n\n", x);
+    printf("d|%6.0f|\n\n", x);
 
     return 0;
 }


### PR DESCRIPTION
%6f prints decimal in case x is a number with a decimal point. %6.0f fixes this.